### PR TITLE
Renamed 'depth' derivative to become 'z' derivative

### DIFF
--- a/examples/otoole_valentine_woodhouse_2012.py
+++ b/examples/otoole_valentine_woodhouse_2012.py
@@ -21,7 +21,7 @@ stations = pp.RegularlyDistributedReceivers(39.6,39.6,1,90-118.2,90-118.2,1,degr
 event = pp.PointSource(0,0,35,rtf2xyz(np.array([[ 0.3406, 0.0005, 0.1610],
                                                 [ 0.0005, 0.7798, 0.1430],
                                                 [ 0.1610, 0.1430, 0.6349]])),np.array([[0.],[0.],[0.]]),0)
-drv = pp.DerivativeSwitches(moment_tensor=True,depth=True,x=True,y=True,time=True)
+drv = pp.DerivativeSwitches(moment_tensor=True,z=True,x=True,y=True,time=True)
 
 stf = lambda w: stf_trapezoidal(w,3,6)*clp_filter(w,0.05*2*np.pi,0.2*2*np.pi)
 tt,seis,deriv = pp.compute_seismograms(model,event,stations,81,0.5,source_time_function = stf,derivatives=drv,pad_frac=0.5)
@@ -67,13 +67,13 @@ plt.tight_layout()
 plt.show()
 
 fig = plt.figure()
-deriv[drv.i_dep,:,:]*=10
+deriv[drv.i_z,:,:]*=10
 deriv[drv.i_x,:,:]*=10
 deriv[drv.i_y,:,:]*=10
 deriv[drv.i_time,:,:]*=2
 amax = abs(deriv[drv.i_mt+6:,:,:]).max()
 amax = 1.025*max([amax,abs(seis).max()])
-dcomp = [drv.i_dep,drv.i_y,drv.i_x,drv.i_time]
+dcomp = [drv.i_z,drv.i_y,drv.i_x,drv.i_time]
 complabel = ["Depth","Latitude","Longitude","Time"]
 for idrv in range(4):
     for icomp in range(3):

--- a/src/pyprop8/_core.py
+++ b/src/pyprop8/_core.py
@@ -613,7 +613,7 @@ class DerivativeSwitches:
         phi=False,
         x=False,
         y=False,
-        depth=False,
+        z=False,
         time=False,
         thickness=False,
         structure=None,
@@ -629,7 +629,7 @@ class DerivativeSwitches:
         :param bool phi: Compute derivatives wrt source-receiver azimuth.
         :param bool x: Compute derivatives wrt x (east-west) location of source.
         :param bool y: Compute derivatives wrt y (north-south) location of source.
-        :param bool depth: Compute derivatives wrt source depth.
+        :param bool z: Compute derivatives wrt z (vertical) location of source.
         :param bool time: Compute derivatives wrt event time.
         :param bool thickness: Compute derivatives wrt layer thicknesses
         :param LayeredStructureModel or None structure: Current model (only
@@ -641,7 +641,7 @@ class DerivativeSwitches:
         self.phi = phi
         self.x = x
         self.y = y
-        self.depth = depth
+        self.z = z
         self.time = time
         self.thickness = thickness
         self.structure = structure
@@ -661,7 +661,7 @@ class DerivativeSwitches:
             n += 1
         if self.y:
             n += 1
-        if self.depth:
+        if self.z:
             n += 1
         if self.time:
             n += 1
@@ -749,8 +749,8 @@ class DerivativeSwitches:
         return i
 
     @property
-    def i_dep(self):
-        if not self.depth:
+    def i_z(self):
+        if not self.z:
             return None
         i = 0
         if self.moment_tensor:
@@ -784,7 +784,7 @@ class DerivativeSwitches:
             i += 1
         if self.y:
             i += 1
-        if self.depth:
+        if self.z:
             i += 1
         return i
 
@@ -805,7 +805,7 @@ class DerivativeSwitches:
             i += 1
         if self.y:
             i += 1
-        if self.depth:
+        if self.z:
             i += 1
         if self.time:
             i += 1
@@ -1072,8 +1072,8 @@ def compute_spectra(
                     for i in range(nsources):
                         d_b[k != 0, i, j0 + j, :4, :] = (H_psv @ s_psv).value
                         d_b[k != 0, i, j0 + j, 4:, :] = (H_sh @ s_sh).value
-            if derivatives.depth:
-                j0 = derivatives.i_dep
+            if derivatives.z:
+                j0 = derivatives.i_z
                 for i in range(nsources):
                     s_psv, s_sh = sourceVector_ddep(
                         source.Mxyz[i, :, :],
@@ -1474,8 +1474,8 @@ def compute_spectra(
                         eimphi,
                         optimize=plan_3,
                     )
-            if derivatives.depth:
-                j0 = derivatives.i_dep
+            if derivatives.z:
+                j0 = derivatives.i_z
                 d_spectra[:, :, ss, j0, 0, iom] = np.einsum(
                     es1, k * k_wts, d_b[:, :, j0, 1, :], jvp, eimphi, optimize=plan_1
                 ) + np.einsum(

--- a/src/pyprop8/tests.py
+++ b/src/pyprop8/tests.py
@@ -38,7 +38,7 @@ def test_spatial_derivatives(
     if source_time_function is None:
         source_time_function = lambda w: stf_trapezoidal(w, 3, 6)
     if derivatives is None:
-        derivatives = pp.DerivativeSwitches(r=True, phi=True, depth=True)
+        derivatives = pp.DerivativeSwitches(r=True, phi=True, z=True)
     if type(delta_scales) is not defaultdict:
         # Make delta_scales have a default value of '1'
         delta_scales = defaultdict(lambda: 1, **delta_scales)
@@ -127,7 +127,7 @@ def test_spatial_derivatives(
         maxerr = (abs(err) / norm.reshape(*norm.shape, 1)).max()
         drverrs += [maxerr]
         print("Max error, 'phi' derivative: %f%%" % (100 * maxerr))
-    if derivatives.depth:
+    if derivatives.z:
         source_pert = source.copy()
         source_pert.dep -= delta * delta_scales["depth"]
         tt, seis = pp.compute_seismograms(
@@ -142,11 +142,11 @@ def test_spatial_derivatives(
             source_time_function=source_time_function,
         )
         fd = (seis - seis0) / delta
-        err = drv[deriv_comp(derivatives.i_dep)] - fd
+        err = drv[deriv_comp(derivatives.i_z)] - fd
         if nDimTime == 0:
-            norm = abs(drv[deriv_comp(derivatives.i_dep)])
+            norm = abs(drv[deriv_comp(derivatives.i_z)])
         else:
-            norm = abs(drv[deriv_comp(derivatives.i_dep)]).max(-1)
+            norm = abs(drv[deriv_comp(derivatives.i_z)]).max(-1)
         maxerr = (abs(err) / norm.reshape(*norm.shape, 1)).max()
         drverrs += [maxerr]
         print("Max error, 'depth' derivative: %f%%" % (100 * maxerr))


### PR DESCRIPTION
Renamed 'depth' derivative to become 'z' derivative to avoid potential for confusion. This derivative represents the change in seismogram due to a *positive* change in the z-coordinate of the seismic source, which is equivalent to a *decrease* in the source depth. 