### PR TITLE
fix missing copy in PointSource

### DIFF
--- a/src/pyprop8/_core.py
+++ b/src/pyprop8/_core.py
@@ -113,8 +113,8 @@ class PointSource:
             self.F = F.copy()
         elif len(Mxyz.shape) == 2:
             self.nsources = 1
-            self.Mxyz = Mxyz.reshape(1, 3, 3)
-            self.F = F.reshape(1, 3, 1)
+            self.Mxyz = Mxyz.copy().reshape(1, 3, 3)
+            self.F = F.copy().reshape(1, 3, 1)
         else:
             raise ValueError("Moment tensor should be (Nx)3x3")
 


### PR DESCRIPTION
Fixes a shallow copy problem.
Example when it may arise:

```python
import pyprop8 as pp
import numpy as np

M = np.zeros((3, 3))
F = np.zeros((3, 1))
p1 = pp.PointSource(
    0,
    0,
    10,
    M,
    F,
    0.0
)
print(p1.Mxyz)
M[0,0]=1
p2 = pp.PointSource(
    0,
    0,
    10,
    M,
    F,
    0.0,
)
print(p1.Mxyz)

```
currently returns:

```
[[[0. 0. 0.]
  [0. 0. 0.]
  [0. 0. 0.]]]
[[[1. 0. 0.]
  [0. 0. 0.]
  [0. 0. 0.]]]
```
